### PR TITLE
Changing PIL imports to work with both PIL and Pillow

### DIFF
--- a/src/dowser/__init__.py
+++ b/src/dowser/__init__.py
@@ -11,8 +11,7 @@ import threading
 import time
 from types import FrameType, ModuleType
 
-import Image
-import ImageDraw
+from PIL import Image, ImageDraw
 
 import cherrypy
 


### PR DESCRIPTION
As per: https://pillow.readthedocs.org/en/latest/porting-pil-to-pillow.html

This means Dowser will run with either PIL or Pillow installed.
